### PR TITLE
Adding script error handler to prevent Angular initialization process getting stuck

### DIFF
--- a/projects/ngx-pendo/src/lib/ngx-pendo.injectors.ts
+++ b/projects/ngx-pendo/src/lib/ngx-pendo.injectors.ts
@@ -27,11 +27,15 @@ export function pendoInitializer($settings: IPendoSettings) {
       return;
     }
 
-    await new Promise(resolve => {
+    await new Promise((resolve, reject) => {
       const script = document.createElement('script');
       script.async = true;
       script.src = `${$settings.pendoScriptOrigin || DEFAULT_PENDO_SCRIPT_ORIGIN}/agent/static/${$settings.pendoApiKey}/pendo.js`;
       document.head.appendChild(script);
+      script.onerror = async () => {
+        // The script may have been blocked by an ad blocker
+        reject();
+      };
       script.onload = async () => {
         // when enableDebugging should load extra js
         const sub = interval(100).subscribe(() => {


### PR DESCRIPTION
With some ad blockers, it is possible for the Pendo script to be blocked. Right now, as this is hooking into the `APP_INITIALIZER` for Angular, the promise must resolve or be rejected before the rest of the app loads.

If the script fails to load, then the `onerror` function will be triggered, rejecting the promise, and allowing the rest of the app to load. This does not handle the issue of a very slow internet connection (where the app is hanging until the script can finish downloading), but it's a start.

This will fix #3 - it is the solution I'm using now to deal with the issue (as my site can have users with adblock).