### PR TITLE
refactor: update DOCUMENT import path

### DIFF
--- a/projects/ngx-pendo/src/lib/ngx-pendo.tokens.ts
+++ b/projects/ngx-pendo/src/lib/ngx-pendo.tokens.ts
@@ -1,4 +1,5 @@
-import { InjectionToken, inject, DOCUMENT } from '@angular/core';
+import { InjectionToken, inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { PendoWindow } from './ngx-pendo.types';
 import { IPendo, IPendoSettings } from './ngx-pendo.interfaces';
 


### PR DESCRIPTION
Changed the import path for DOCUMENT from '@angular/core' to '@angular/common' to follow Angular's recommended practices. This improves code consistency and maintainability.

Closes #120